### PR TITLE
BUGFIX: broken references in NeosFusionReference.rst

### DIFF
--- a/Neos.Neos/Documentation/References/NeosFusionReference.rst
+++ b/Neos.Neos/Documentation/References/NeosFusionReference.rst
@@ -474,7 +474,7 @@ Example::
     value = ${1+2}
   }
 
-.. _Neos_Fusion__Tag:
+.. _Neos_Fusion__DataStructure:
 
 
 Neos.Fusion:DataStructure
@@ -694,7 +694,7 @@ Neos.Fusion:Link.Resource
 Renders a link pointing to a resource
 
 :content: (string) content of the link tag
-:href: (string,  default :ref:`Neos_Fusion__ResouceUri`) The href for the link tag
+:href: (string,  default :ref:`Neos_Fusion__ResourceUri`) The href for the link tag
 :[key]: (string) Other attributes for the link tag
 
 Example::
@@ -1038,7 +1038,7 @@ The following fusion properties are passed over to :ref:`Neos_Neos__DimensionsMe
 :renderHiddenInIndex: (boolean, default **true**) If TRUE, render nodes which are marked as "hidded-in-index"
 :calculateItemStates: (boolean) activate the *expensive* calculation of item states defaults to ``false``
 
-.. note:: The ``items`` of the ``DimensionsMenu`` are internally calculated with the prototype :ref:`Neos_Neos__DimensionsMenuMenuItems` which
+.. note:: The ``items`` of the ``DimensionsMenu`` are internally calculated with the prototype :ref:`Neos_Neos__DimensionsMenuItems` which
    you can use directly aswell.
 
 .. note:: The ``rendering`` of the ``DimensionsMenu`` is performed with the prototype :ref:`Neos_Neos__MenuItemListRenderer`.


### PR DESCRIPTION
Followup to #4647

Currently every reference to Tag and DataStructure is broken.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
